### PR TITLE
Fix "Invalid Pointer" error that can occur under certain circumstances.

### DIFF
--- a/comp/uMySFTPClient.pas
+++ b/comp/uMySFTPClient.pas
@@ -1916,7 +1916,7 @@ begin
       end;
     until (N <= 0) or FCanceled;
   finally
-    FreeMem(Buf);
+    FreeMem(StartBuf);
     libssh2_sftp_close(FHandle);
   end;
 end;


### PR DESCRIPTION
Fix "Invalid Pointer" error that can occur under certain circumstances.
One example of a situation where this can happen is if the progress callback throws an exception.